### PR TITLE
Hide duplicate routes added by transport canberra

### DIFF
--- a/.github/workflows/generate_canberra.yml
+++ b/.github/workflows/generate_canberra.yml
@@ -3,6 +3,8 @@ name: Generate for Canberra
 on:
   push:
     branches: [ "main", "develop" ]
+  pull_request:
+    branches: "main"
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"

--- a/config-canberra.yml
+++ b/config-canberra.yml
@@ -102,6 +102,136 @@ route:
       search-weight: 1.7
     10:
       search-weight: 1.7
+    2-10647:
+      hidden: true
+    3-10647:
+      hidden: true
+    4-10647:
+      hidden: true
+    5-10647:
+      hidden: true
+    6-10647:
+      hidden: true
+    7-10647:
+      hidden: true
+    8-10647:
+      hidden: true
+    9-10647:
+      hidden: true
+    10-10647:
+      hidden: true
+    18-10647:
+      hidden: true
+    19-10647:
+      hidden: true
+    20-10647:
+      hidden: true
+    21-10647:
+      hidden: true
+    22-10647:
+      hidden: true
+    23-10647:
+      hidden: true
+    24-10647:
+      hidden: true
+    25-10647:
+      hidden: true
+    26-10647:
+      hidden: true
+    27-10647:
+      hidden: true
+    28-10647:
+      hidden: true
+    30-10647:
+      hidden: true
+    31-10647:
+      hidden: true
+    32-10647:
+      hidden: true
+    40-10647:
+      hidden: true
+    41-10647:
+      hidden: true
+    42-10647:
+      hidden: true
+    43-10647:
+      hidden: true
+    44-10647:
+      hidden: true
+    45-10647:
+      hidden: true
+    46-10647:
+      hidden: true
+    47-10647:
+      hidden: true
+    50-10647:
+      hidden: true
+    51-10647:
+      hidden: true
+    53-10647:
+      hidden: true
+    54-10647:
+      hidden: true
+    55-10647:
+      hidden: true
+    56-10647:
+      hidden: true
+    57-10647:
+      hidden: true
+    58-10647:
+      hidden: true
+    59-10647:
+      hidden: true
+    60-10647:
+      hidden: true
+    61-10647:
+      hidden: true
+    62-10647:
+      hidden: true
+    63-10647:
+      hidden: true
+    64-10647:
+      hidden: true
+    65-10647:
+      hidden: true
+    66-10647:
+      hidden: true
+    70-10647:
+      hidden: true
+    71-10647:
+      hidden: true
+    72-10647:
+      hidden: true
+    73-10647:
+      hidden: true
+    74-10647:
+      hidden: true
+    75-10647:
+      hidden: true
+    76-10647:
+      hidden: true
+    77-10647:
+      hidden: true
+    78-10647:
+      hidden: true
+    79-10647:
+      hidden: true
+    80-10647:
+      hidden: true
+    81-10647:
+      hidden: true
+    180-10647:
+      hidden: true
+    181-10647:
+      hidden: true
+    182-10647:
+      hidden: true
+    901-10647:
+      hidden: true
+    902-10647:
+      hidden: true
+    903-10647:
+      hidden: true
 stops:
   modifications:
     "959":


### PR DESCRIPTION
Of course Transport Canberra used the protocol wrong