### PR TITLE
Generate a stable service ID based on active configuration

### DIFF
--- a/preprocessor/preprocessor.py
+++ b/preprocessor/preprocessor.py
@@ -1,10 +1,12 @@
+import base64
+import hashlib
 from pathlib import Path
 
 import click
 import pandas as pd
 
 
-def map_route(route_id: str) -> str:
+def map_route_id(route_id: str) -> str:
     r = route_id.partition("_")[0]
 
     if r == "1":
@@ -17,6 +19,23 @@ def map_route(route_id: str) -> str:
 
 def combine_routes(df: pd.DataFrame):
     return df.drop_duplicates(subset='route_id', keep='first')
+
+
+service_id_map = {}
+
+
+def generate_service_id_map(calendar_csv: pd.DataFrame):
+    for index, row in calendar_csv.iterrows():
+        service_id_map[f"{row['service_id']}"] = base64.urlsafe_b64encode(
+            hashlib.sha1((f"{row['service_id']},{row['monday']},{row['tuesday']},"
+                          "{row['wednesday']},{row['thursday']},{row['friday']},"
+                          "{row['saturday']},{row['sunday']},{row['start_date']},"
+                          "{row['end_date']}").encode("utf-8")).digest()
+        ).decode("utf-8")[0:16]
+
+
+def map_service_id(service_id: str) -> str:
+    return service_id_map[f"{service_id}"]
 
 
 @click.group()
@@ -39,10 +58,16 @@ def process(
     stop_time_csv = pd.read_csv(Path(input_folder).joinpath("stop_times.txt"), keep_default_na=False)
     trips_csv = pd.read_csv(Path(input_folder).joinpath("trips.txt"), keep_default_na=False)
 
-    route_csv['route_id'] = route_csv['route_id'].apply(map_route)
-    route_csv = combine_routes(route_csv)
+    generate_service_id_map(calendar_csv)
 
-    trips_csv['route_id'] = trips_csv['route_id'].apply(map_route)
+    calendar_csv['service_id'] = calendar_csv['service_id'].apply(map_service_id)
+    calendar_date_csv['service_id'] = calendar_date_csv['service_id'].apply(map_service_id)
+    trips_csv['service_id'] = trips_csv['service_id'].apply(map_service_id)
+
+    route_csv['route_id'] = route_csv['route_id'].apply(map_route_id)
+    trips_csv['route_id'] = trips_csv['route_id'].apply(map_route_id)
+
+    route_csv = combine_routes(route_csv)
 
     Path(output_folder).mkdir(parents=True, exist_ok=True)
     stop_csv.to_csv(Path(output_folder).joinpath("stops.txt"), index=False)


### PR DESCRIPTION
Transport Canberra have entirely renumbered service IDs twice at this point (one week into the API being active). There is no indication that they won't recycle the number every time a service passes its end date.

Given this, a secondary unique and stable service ID needs to be generated. This is generated by hashing all the fields of the calendar.txt row that makes up a service. To be safe, the original service ID is also included in the hash, but this may not be necessary in the future and may be removed.
